### PR TITLE
Enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ attributes <- ( '[' attribute ( ',' attribute )* ']' )+
 attribute <- identifier ( '(' ( value ( ',' value )* )? ')' )?
 
 typedef <- attributes? 'type' identifier ( ':' identifier )? ( '{' field* '}' / ';' )
-field <- attributes? identifier identifier ( '=' value )? ';'
+field <- attributes? identifier identifier ( '=' value / '=' identifier )? ';'
 
 enumdef <- attributes? 'enum' ( ':' identifier )? '{' enumvalue ( ',' enumvalue )* '}'
 enumvalue <- identifier ( '=' number )?
@@ -70,10 +70,17 @@ type int;
 
 attribute cdecl { string name; }
 
+enum flags {
+    none,
+    first = 10,
+    last = 20
+}
+
 [cdecl("test_t")]
 type test {
 	[cdecl("t_num")]
 	int num = 0;
+    flags flg = first;
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Simplified PEG grammar.
 
 ```
 file <- module pragma* statement*
-statement <- attrdef / typedef / import / include
+statement <- attrdef / typedef / enumdef / import / include
 module <- 'module' identifier ';'
 pragma <- 'pragma' identifier ';'
 
@@ -55,6 +55,9 @@ attribute <- identifier ( '(' ( value ( ',' value )* )? ')' )?
 
 typedef <- attributes? 'type' identifier ( ':' identifier )? ( '{' field* '}' / ';' )
 field <- attributes? identifier identifier ( '=' value )? ';'
+
+enumdef <- attributes? 'enum' ( ':' identifier )? '{' enumvalue ( ',' enumvalue )* '}'
+enumvalue <- identifier ( '=' number )?
 ```
 
 Example:

--- a/example/gen_header.py
+++ b/example/gen_header.py
@@ -96,9 +96,9 @@ def main(argv):
 
         if 'is_enumeration' in type and type['is_enumeration']:
             if basetype:
-                print(f'  enum {name} : {cxxname(basetype)} {{', file=args.output)
+                print(f'  enum class {name} : {cxxname(basetype)} {{', file=args.output)
             else:
-                print(f'  enum {name} {{', file=args.output)
+                print(f'  enum class {name} {{', file=args.output)
 
             for value in type['values']:
                 print(f'    {identifier(value["name"])} = {encode(value["value"])},', file=args.output)
@@ -119,7 +119,10 @@ def main(argv):
                     field_cxxtype = f'std::vector<{field_cxxtype}>'
 
                 if ('default' in field):
-                    print(f'    {field_cxxtype} {cxxname(field)} = {encode(field["default"])};', file=args.output)
+                    if 'is_enumeration' in field_type and field_type['is_enumeration']:
+                        print(f'    {field_cxxtype} {cxxname(field)} = ({field_cxxtype}){encode(field["default"])};', file=args.output)
+                    else:
+                        print(f'    {field_cxxtype} {cxxname(field)} = {encode(field["default"])};', file=args.output)
                 else:
                     print(f'    {field_cxxtype} {cxxname(field)};', file=args.output)
 

--- a/example/gen_header.py
+++ b/example/gen_header.py
@@ -94,25 +94,34 @@ def main(argv):
 
         basetype = typemap[type['base']] if 'base' in type else None
 
-        if basetype:
-            print(f'  struct {name} : {cxxname(basetype)} {{', file=args.output)
-        else:
-            print(f'  struct {name} {{', file=args.output)
-
-        for field in type['fields']:
-            if ignored(field): continue
-
-            field_type = typemap[field["type"]]
-            field_cxxtype = cxxname(field_type)
-            if "is_pointer" in field and field["is_pointer"]:
-                field_cxxtype = f'std::unique_ptr<{field_cxxtype}>'
-            if "is_array" in field and field["is_array"]:
-                field_cxxtype = f'std::vector<{field_cxxtype}>'
-
-            if ('default' in field):
-                print(f'    {field_cxxtype} {cxxname(field)} = {encode(field["default"])};', file=args.output)
+        if 'is_enumeration' in type and type['is_enumeration']:
+            if basetype:
+                print(f'  enum {name} : {cxxname(basetype)} {{', file=args.output)
             else:
-                print(f'    {field_cxxtype} {cxxname(field)};', file=args.output)
+                print(f'  enum {name} {{', file=args.output)
+
+            for value in type['values']:
+                print(f'    {identifier(value["name"])} = {encode(value["value"])},', file=args.output)
+        else:
+            if basetype:
+                print(f'  struct {name} : {cxxname(basetype)} {{', file=args.output)
+            else:
+                print(f'  struct {name} {{', file=args.output)
+
+            for field in type['fields']:
+                if ignored(field): continue
+
+                field_type = typemap[field["type"]]
+                field_cxxtype = cxxname(field_type)
+                if "is_pointer" in field and field["is_pointer"]:
+                    field_cxxtype = f'std::unique_ptr<{field_cxxtype}>'
+                if "is_array" in field and field["is_array"]:
+                    field_cxxtype = f'std::vector<{field_cxxtype}>'
+
+                if ('default' in field):
+                    print(f'    {field_cxxtype} {cxxname(field)} = {encode(field["default"])};', file=args.output)
+                else:
+                    print(f'    {field_cxxtype} {cxxname(field)};', file=args.output)
 
         print(f'  }};', file=args.output)
         print(f'}}', file=args.output)

--- a/example/include/base.sap
+++ b/example/include/base.sap
@@ -6,3 +6,10 @@ attribute name { string name; } # this is another comment
 
 [ignore, name("boolean")]
 type bool2;
+
+enum flags {
+    none = 0,
+    base = 1,
+    second,
+    last
+}

--- a/example/test.sap
+++ b/example/test.sap
@@ -31,3 +31,11 @@ type test {
 }
 
 type derived : test;
+
+enum order {
+    first, second, third
+}
+
+type ordered {
+    order position = second;
+}

--- a/source/context.cc
+++ b/source/context.cc
@@ -92,7 +92,17 @@ void rePushEnumValue(struct reParseState* state, struct reID name, struct reID v
     else if (!state->enumValueStack.empty())
         init = state->enumValueStack.back().value + 1;
 
-    state->enumValueStack.push_back({ get_string(state, name), init, {}, state->location(loc) });
+    auto nameStr = get_string(state, name);
+
+    for (auto const& enumValue : state->enumValueStack) {
+        if (enumValue.name == nameStr) {
+            state->error(state->location(loc), "duplicate enumerant '", nameStr, '\'');
+            state->error(enumValue.loc, "previous enumerant '", nameStr, "' defined here");
+            return;
+        }
+    }
+
+    state->enumValueStack.push_back({ std::move(nameStr), init, {}, state->location(loc) });
 }
 
 void rePushEnumDefinition(struct reParseState* state, struct reID name, struct reID base, struct reLoc loc) {

--- a/source/context.cc
+++ b/source/context.cc
@@ -151,5 +151,5 @@ void rePragma(struct reParseState* state, struct reID name, struct reLoc loc) {
 }
 
 void reError(struct reParseState* state, reLoc loc, char const* message) {
-    state->error(state->location(loc), "at ", loc.position, ": ", message);
+    state->error(state->location(loc), ": ", message);
 }

--- a/source/context.h
+++ b/source/context.h
@@ -51,6 +51,9 @@ extern "C" {
     void rePushField(struct reParseState* state, struct reID type, struct reID isPointer, struct reID isArray, struct reID name, struct reID init, struct reLoc loc);
     void rePushTypeDefinition(struct reParseState* state, struct reID name, struct reID base, struct reLoc loc);
 
+    void rePushEnumValue(struct reParseState* state, struct reID name, struct reID value, struct reLoc loc);
+    void rePushEnumDefinition(struct reParseState* state, struct reID name, struct reID base, struct reLoc loc);
+
     void rePushAttributeArgument(struct reParseState* state, struct reID id);
     void rePushAttribute(struct reParseState* state, struct reID name, struct reLoc loc);
 

--- a/source/sapc.peg
+++ b/source/sapc.peg
@@ -33,7 +33,7 @@
 
 # file
 file <- _ module ( _ pragma )* ( _ statement )* _ !.
-statement <- ( attrdef / typedef / import / include )
+statement <- ( attrdef / typedef / enumdef / import / include )
 module <- 'module' _ m:identifier _ ';' { reModuleName(RE_STATE, m, RE_LOC); } ~{ RE_FAIL($0s, "missing module declaration"); }
 pragma <- 'pragma' _ i:identifier _ ';'
 
@@ -74,3 +74,7 @@ typebase <- ':' _ n:identifier { $$ = n; } / { $$ = RE_NONE; }
 field <- attributes _ t:identifier _ p:fieldptr _ a:fieldarray _ n:identifier _ v:initializer _ ';' { rePushField(RE_STATE, t, p, a, n, v, RE_LOC); }
 fieldptr <- '*' { $$ = rePushBoolean(RE_STATE, 1); } / { $$ = rePushBoolean(RE_STATE, 0); }
 fieldarray <- '[]' { $$ = rePushBoolean(RE_STATE, 1); } / { $$ = rePushBoolean(RE_STATE, 0); }
+
+# enumerations
+enumdef <- attributes _ 'enum' _ n:identifier _ b:typebase? _ '{' _ enumvalue ( _ ',' _ enumvalue )* _ '}'
+enumvalue <- i:identifier ( _ '=' _ n:number )?

--- a/source/sapc.peg
+++ b/source/sapc.peg
@@ -42,7 +42,7 @@ import <- 'import' _ f:identifier _ ';' { reImport(RE_STATE, f, RE_LOC); }
 include <- 'include' _ p:string space? linecomment? eol { reInclude(RE_STATE, p, RE_LOC); } eol
 
 # values
-value <- ( v:number { $$ = v; } / v:string { $$ = v; } / v:true { $$ = v; } / v:false { $$ = v; } / v:null { $$ = v; } ) ~{ RE_FAIL($0s, "expected value"); }
+value <- ( v:number { $$ = v; } / v:string { $$ = v; } / v:true { $$ = v; } / v:false { $$ = v; } / v:null { $$ = v; } / v:identifier { $$ = v; } ) ~{ RE_FAIL($0s, "expected value"); }
 number <- <'-'? [0-9]+> { $$ = rePushNumber(RE_STATE, $1); }
 string <- '"' <[^"\n]*> '"' { $$ = rePushString(RE_STATE, $1); }
 true <- 'true' { $$ = rePushBoolean(RE_STATE, 1); }
@@ -57,7 +57,7 @@ comment <- linecomment eol / blockcomment
 linecomment <- ( '//' / '#' ) [^\n]*
 blockcomment <- '/*' ( eol / !'*/' . )* '*/' ~{ RE_FAIL($0s, "invalid block comment"); }
 identifier <- <[a-zA-Z_][a-zA-Z0-9_]*> { $$ = rePushIdentifier(RE_STATE, $1); }
-initializer <- '=' _ v:value { $$ = v; } / '=' _ v:identifier { $$ = v; } / { $$ = RE_NONE; }
+initializer <- '=' _ v:value { $$ = v; } / { $$ = RE_NONE; }
 
 # attribute definitions
 attrdef <- 'attribute' _ n:identifier _ ( '{' (_ attrparam )* _ '}' / ';' ) { rePushAttributeDefinition(RE_STATE, n, RE_LOC); }

--- a/source/sapc.peg
+++ b/source/sapc.peg
@@ -76,5 +76,6 @@ fieldptr <- '*' { $$ = rePushBoolean(RE_STATE, 1); } / { $$ = rePushBoolean(RE_S
 fieldarray <- '[]' { $$ = rePushBoolean(RE_STATE, 1); } / { $$ = rePushBoolean(RE_STATE, 0); }
 
 # enumerations
-enumdef <- attributes _ 'enum' _ n:identifier _ b:typebase? _ '{' _ enumvalue ( _ ',' _ enumvalue )* _ '}'
-enumvalue <- i:identifier ( _ '=' _ n:number )?
+enumdef <- attributes _ 'enum' _ n:identifier _ b:typebase? _ '{' _ enumvalue ( _ ',' _ enumvalue )* _ '}' { rePushEnumDefinition(RE_STATE, n, b, RE_LOC); }
+enumvalue <- i:identifier _ v:enuminit { rePushEnumValue(RE_STATE, i, v, RE_LOC); }
+enuminit <- '=' _ n:number { $$ = n; } / { $$ = RE_NONE; }

--- a/source/sapc.peg
+++ b/source/sapc.peg
@@ -57,7 +57,7 @@ comment <- linecomment eol / blockcomment
 linecomment <- ( '//' / '#' ) [^\n]*
 blockcomment <- '/*' ( eol / !'*/' . )* '*/' ~{ RE_FAIL($0s, "invalid block comment"); }
 identifier <- <[a-zA-Z_][a-zA-Z0-9_]*> { $$ = rePushIdentifier(RE_STATE, $1); }
-initializer <- '=' _ v:value { $$ = v; } / { $$ = RE_NONE; }
+initializer <- '=' _ v:value { $$ = v; } / '=' _ v:identifier { $$ = v; } / { $$ = RE_NONE; }
 
 # attribute definitions
 attrdef <- 'attribute' _ n:identifier _ ( '{' (_ attrparam )* _ '}' / ';' ) { rePushAttributeDefinition(RE_STATE, n, RE_LOC); }

--- a/source/state.hh
+++ b/source/state.hh
@@ -60,13 +60,22 @@ namespace sapc {
         Location loc;
     };
 
+    struct EnumValue {
+        std::string name;
+        long long value = 0;
+        std::vector<Attribute> attributes;
+        Location loc;
+    };
+
     struct Type {
         std::string name;
         std::string base;
         std::vector<Attribute> attributes;
         std::vector<Field> fields;
+        std::vector<EnumValue> values;
         Location loc;
         bool attribute = false;
+        bool enumeration = false;
         bool imported = false;
         bool builtin = false;
     };
@@ -102,6 +111,7 @@ namespace sapc {
         std::vector<Field> attributeParamStack;
         std::vector<std::vector<Attribute>> attributeSetStack;
         std::vector<reID> argumentStack;
+        std::vector<EnumValue> enumValueStack;
         std::vector<std::filesystem::path> pathStack;
 
         std::vector<std::string> pragmas;


### PR DESCRIPTION
Add enumerations.

```
enum flags {
  name = value,
  name2 = value2,
  name3,
  name4
}
```

Auto-assigns values using the same rules as C (one plus last value, starting at 0).

Can initialize fields of enum type based on an initializer:

```
type data {
  flags options = name3;
}
```

Todo:
- [x] Check for and error on duplicate enumeration names.
- [x] Check for and validate field initializers for enums.

Closes #1 