### PR TITLE
Struct vs type

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Simplified PEG grammar.
 
 ```
 file <- statement*
-statement <- attrdef / typedef / enumdef / import / pragma / module
+statement <- attribute / type / struct / enum/ import / pragma / module
 
 module <- 'module' identifier ';'
 pragma <- 'pragma' identifier ';'
@@ -46,17 +46,19 @@ linecomment <- ( '#' / '//' ) [^\n]*
 blockcomment <- '/*' .* '*/'
 identifier <- [a-zA-Z_][a-zA-Z0-9_]*
 
-attrdef <- 'attribute' identifier ( '{' attrparam* '}' / ';' )
-attrparam <- identifier identifier ( '=' value )? ';'
+attribute <- 'attribute' identifier ( '{' attribute_parameter* '}' / ';' )
+attribute_parameter <- identifier identifier ( '=' value )? ';'
 
-attributes <- ( '[' attribute ( ',' attribute )* ']' )+
-attribute <- identifier ( '(' ( value ( ',' value )* )? ')' )?
+attributes <- ( '[' attribute_usage ( ',' attribute_usage )* ']' )+
+attribute_usage <- identifier ( '(' ( value ( ',' value )* )? ')' )?
 
-typedef <- attributes? 'type' identifier ( ':' identifier )? ( '{' field* '}' / ';' )
+type <- attributes? 'type' identifier ';'
+
+struct <- attributes? 'struct' identifier ( ':' identifier )? ( '{' field* '}' / ';' )
 field <- attributes? identifier identifier ( '=' value / '=' identifier )? ';'
 
-enumdef <- attributes? 'enum' ( ':' identifier )? '{' enumvalue ( ',' enumvalue )* '}'
-enumvalue <- identifier ( '=' number )?
+enum <- attributes? 'enum' ( ':' identifier )? '{' enumerant ( ',' enumerant )* '}'
+enumerant <- identifier ( '=' number )?
 ```
 
 Example:
@@ -76,7 +78,7 @@ enum flags {
 }
 
 [cdecl("test_t")]
-type test {
+struct test {
     [cdecl("t_num")]
     int num = 0;
     flags flg = first;

--- a/example/test.sap
+++ b/example/test.sap
@@ -13,7 +13,7 @@ attribute default { any value = 0; } /* default attribute */
 [cxxname("int*"), ignore]
 type intptr;
 [name("Test")]
-type test {
+struct test {
     [default]
     i32 x = 0 # a comment
     ;
@@ -28,12 +28,12 @@ type test {
     bool[] bits;
 }
 
-type derived : test;
+struct derived : test {}
 
 enum order {
     first, second, third
 }
 
-type ordered {
+struct ordered {
     order position = second;
 }

--- a/source/lexer.cc
+++ b/source/lexer.cc
@@ -38,6 +38,7 @@ namespace sapc {
         case TokenType::KeywordAttribute: os << "`attribute'"; break;
         case TokenType::KeywordEnum: os << "`enum'"; break;
         case TokenType::KeywordTrue: os << "`true'"; break;
+        case TokenType::KeywordStruct: os << "`struct'"; break;
         case TokenType::KeywordFalse: os << "`false'"; break;
         case TokenType::KeywordNull: os << "`null'"; break;
         case TokenType::EndOfFile: os << "end of file"; break;
@@ -106,6 +107,7 @@ namespace sapc {
             { "pragma", TokenType::KeywordPragma, true },
             { "attribute", TokenType::KeywordAttribute, true },
             { "type", TokenType::KeywordType, true },
+            { "struct", TokenType::KeywordStruct, true },
             { "enum", TokenType::KeywordEnum, true },
             { "true", TokenType::KeywordTrue, true },
             { "false", TokenType::KeywordFalse, true },

--- a/source/lexer.hh
+++ b/source/lexer.hh
@@ -28,6 +28,7 @@ namespace sapc {
         KeywordImport,
         KeywordPragma,
         KeywordType,
+        KeywordStruct,
         KeywordAttribute,
         KeywordEnum,
         KeywordTrue,


### PR DESCRIPTION
Implements the `struct` keyword.

`struct` requires fields and curly brackets. `type` has no fields and cannot have a base.

The idea is that the latter can be used to declare primitive, e.g. `type int;`

Addresses part of #16 