### PR TITLE
Rename attributes to annotations (in usage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Simplified PEG grammar.
 
 ```
 file <- statement*
-statement <- attribute / type / struct / enum / import / module
+statement <- module / import / definition
+definition <- attribute / type / struct / enum / union
 
 import <- 'import' identifier ';'
 
@@ -45,23 +46,23 @@ blockcomment <- '/*' .* '*/'
 identifier <- [a-zA-Z_][a-zA-Z0-9_]*
 type_info <- identifier ( '[' ']' )?
 
-attributes <- ( '[' attribute_usage ( ',' attribute_usage )* ']' )+
-attribute_usage <- identifier ( '(' ( value ( ',' value )* )? ')' )?
+annotations <- ( '[' annotation ( ',' annotation )* ']' )+
+annotation <- identifier ( '(' ( value ( ',' value )* )? ')' )?
 
-attribute <- 'attribute' identifier ( '{' attribute_parameter* '}' / ';' )
-attribute_parameter <- type_info identifier ( '=' value )? ';'
+attribute <- 'attribute' identifier ( '{' attribute_param* '}' / ';' )
+attribute_param <- type_info identifier ( '=' value )? ';'
 
-module <- attributes? 'module' identifier ';'
+module <- annotations? 'module' identifier ';'
 
-type <- attributes? 'type' identifier ';'
+type <- annotations? 'type' identifier ';'
 
-struct <- attributes? 'struct' identifier ( ':' identifier )? ( '{' struct_field* '}' / ';' )
-struct_field <- attributes? type_info identifier ( '=' value / '=' identifier )? ';'
+struct <- annotations? 'struct' identifier ( ':' identifier )? ( '{' struct_field* '}' / ';' )
+struct_field <- annotations? type_info identifier ( '=' value / '=' identifier )? ';'
 
-union <- attributes? 'union' identifier '{' union_element ( ',' union_element )* '}'
+union <- annotations? 'union' identifier '{' union_element ( ',' union_element )* '}'
 union_element <- type_info
 
-enum <- attributes? 'enum' ( ':' identifier )? '{' enum_value ( ',' enum_value )* '}'
+enum <- annotations? 'enum' ( ':' identifier )? '{' enum_value ( ',' enum_value )* '}'
 enum_value <- identifier ( '=' number )?
 ```
 

--- a/schema/sap-1.schema.json
+++ b/schema/sap-1.schema.json
@@ -34,7 +34,7 @@
         "is_attribute": { "type": "boolean" },
         "is_enumeration": { "type": "boolean" },
         "is_union": { "type": "boolean" },
-        "attributes": { "$ref": "#/definitions/attributes" },
+        "annotations": { "$ref": "#/definitions/annotations" },
         "location": { "$ref": "#/definitions/location" },
         "fields": {
           "type": "array",
@@ -42,16 +42,16 @@
         }
       }
     },
-    "attributes": {
+    "annotations": {
       "type": "object",
       "patternProperties": {
         "^[a-zA-Z0-9_]+$": {
           "type": "array",
-          "items": { "$ref": "#/definitions/attribute" }
+          "items": { "$ref": "#/definitions/annotation" }
         }
       }
     },
-    "attribute": {
+    "annotation": {
       "type": "object",
       "patternProperties": {
         "^[a-zA-Z0-9_]+$": {
@@ -74,7 +74,7 @@
         "name": { "type": "string" },
         "type": { "type": "string" },
         "default": { "$ref": "#/definitions/value" },
-        "attributes": { "$ref": "#/definitions/attributes" },
+        "annotations": { "$ref": "#/definitions/annotations" },
         "is_array": { "type": "boolean" },
         "location": { "$ref": "#/definitions/location" }
       }

--- a/source/analyze.cc
+++ b/source/analyze.cc
@@ -72,7 +72,7 @@ namespace sapc {
                 return;
             }
 
-            auto const argc = annotation.params.size();
+            auto const argc = annotation.arguments.size();
             auto const& attrType = module.types[it->second];
             auto const& params = attrType.fields;
 
@@ -92,7 +92,7 @@ namespace sapc {
                 if (param.init.type == Value::Type::None)
                     error(param.init.location, "missing required argument `", param.name, "' to attribute `", annotation.name, '\'');
                 else
-                    annotation.params.push_back(param.init);
+                    annotation.arguments.push_back(param.init);
             }
         };
 

--- a/source/analyze.cc
+++ b/source/analyze.cc
@@ -64,25 +64,25 @@ namespace sapc {
             }
         }
 
-        // expand attribute parameters
-        auto expand = [&](Attribute& attr) {
-            auto const it = module.typeMap.find(attr.name);
+        // expand attribute arguments
+        auto expand = [&](Annotation& annotation) {
+            auto const it = module.typeMap.find(annotation.name);
             if (it == module.typeMap.end()) {
-                error(attr.location, "unknown attribute `", attr.name, '\'');
+                error(annotation.location, "unknown attribute `", annotation.name, '\'');
                 return;
             }
 
-            auto const argc = attr.params.size();
+            auto const argc = annotation.params.size();
             auto const& attrType = module.types[it->second];
             auto const& params = attrType.fields;
 
             if (attrType.category != Type::Category::Attribute) {
-                error(attr.location, "attribute type `", attr.name, "' is declared as a regular type (not attribute) at ", attrType.location);
+                error(annotation.location, "attribute type `", annotation.name, "' is declared as a regular type (not attribute) at ", attrType.location);
                 return;
             }
 
             if (argc > params.size()) {
-                error(attr.location, "too many arguments to attribute `", attr.name, '\'');
+                error(annotation.location, "too many arguments to attribute `", annotation.name, '\'');
                 return;
             }
 
@@ -90,19 +90,19 @@ namespace sapc {
                 auto const& param = params[index];
 
                 if (param.init.type == Value::Type::None)
-                    error(param.init.location, "missing required argument `", param.name, "' to attribute `", attr.name, '\'');
+                    error(param.init.location, "missing required argument `", param.name, "' to attribute `", annotation.name, '\'');
                 else
-                    attr.params.push_back(param.init);
+                    annotation.params.push_back(param.init);
             }
         };
 
         for (auto& type : module.types) {
-            for (auto& attr : type.attributes)
-                expand(attr);
+            for (auto& annotation : type.annotations)
+                expand(annotation);
 
             for (auto& field : type.fields) {
-                for (auto& attr : field.attributes)
-                    expand(attr);
+                for (auto& annotation : field.annotations)
+                    expand(annotation);
             }
         }
 

--- a/source/grammar.cc
+++ b/source/grammar.cc
@@ -147,7 +147,7 @@ namespace sapc {
                     if (consume(TokenType::LeftParen)) {
                         if (!consume(TokenType::RightParen)) {
                             for (;;) {
-                                auto& value = annotation.params.emplace_back();
+                                auto& value = annotation.arguments.emplace_back();
                                 expectValue(value);
                                 if (!consume(TokenType::Comma))
                                     break;

--- a/source/grammar.cc
+++ b/source/grammar.cc
@@ -138,16 +138,16 @@ namespace sapc {
             } \
         } while(false)
 
-        auto parseAttributes = [&](std::vector<Attribute>& attrs) -> bool {
+        auto parseAnnotations = [&](std::vector<Annotation>& annotations) -> bool {
             while (consume(TokenType::LeftBracket)) {
                 do {
-                    auto& attr = attrs.emplace_back();
-                    expect(TokenType::Identifier, attr.name);
-                    attr.location = pos();
+                    auto& annotation = annotations.emplace_back();
+                    expect(TokenType::Identifier, annotation.name);
+                    annotation.location = pos();
                     if (consume(TokenType::LeftParen)) {
                         if (!consume(TokenType::RightParen)) {
                             for (;;) {
-                                auto& value = attr.params.emplace_back();
+                                auto& value = annotation.params.emplace_back();
                                 expectValue(value);
                                 if (!consume(TokenType::Comma))
                                     break;
@@ -257,9 +257,9 @@ namespace sapc {
                 continue;
             }
 
-            // optionally build up a list of attributes
-            std::vector<Attribute> attributes;
-            if (!parseAttributes(attributes))
+            // optionally build up a list of annotations
+            std::vector<Annotation> annotations;
+            if (!parseAnnotations(annotations))
                 return false;
 
             // parse module
@@ -269,7 +269,7 @@ namespace sapc {
                 expect(TokenType::Identifier, module.name);
                 expect(TokenType::SemiColon);
 
-                module.attributes = std::move(attributes);
+                module.annotations = std::move(annotations);
                 continue;
             }
 
@@ -278,7 +278,7 @@ namespace sapc {
                 auto type = Type{};
                 type.category = Type::Category::Opaque;
 
-                type.attributes = std::move(attributes);
+                type.annotations = std::move(annotations);
                 expect(TokenType::Identifier, type.name);
 
                 type.location = pos();
@@ -294,7 +294,7 @@ namespace sapc {
                 auto union_ = Type{};
                 union_.category = Type::Category::Union;
 
-                union_.attributes = std::move(attributes);
+                union_.annotations = std::move(annotations);
                 expect(TokenType::Identifier, union_.name);
 
                 union_.location = pos();
@@ -319,7 +319,7 @@ namespace sapc {
                 auto type = Type{};
                 type.category = Type::Category::Struct;
 
-                type.attributes = std::move(attributes);
+                type.annotations = std::move(annotations);
                 expect(TokenType::Identifier, type.name);
 
                 type.location = pos();
@@ -329,7 +329,7 @@ namespace sapc {
                 expect(TokenType::LeftBrace);
                 while (!consume(TokenType::RightBrace)) {
                     auto& field = type.fields.emplace_back();
-                    if (!parseAttributes(field.attributes))
+                    if (!parseAnnotations(field.annotations))
                         return false;
                     if (!parseType(field.type))
                         return false;
@@ -349,7 +349,7 @@ namespace sapc {
                 auto enum_ = Type{};
                 enum_.category = Type::Category::Enum;
 
-                enum_.attributes = std::move(attributes);
+                enum_.annotations = std::move(annotations);
                 expect(TokenType::Identifier, enum_.name);
 
                 enum_.location = pos();

--- a/source/model.cc
+++ b/source/model.cc
@@ -42,11 +42,11 @@ namespace sapc {
                 assert(def.category == Type::Category::Attribute);
 
                 auto args_json = json::object();
-                for (size_t index = 0; index != annotation.params.size(); ++index) {
-                    assert(def.fields.size() == annotation.params.size());
+                for (size_t index = 0; index != annotation.arguments.size(); ++index) {
+                    assert(def.fields.size() == annotation.arguments.size());
 
                     auto const& param = def.fields[index];
-                    auto const& arg = annotation.params[index];
+                    auto const& arg = annotation.arguments[index];
 
                     assert(arg.type != Value::Type::None);
                     args_json[param.name] = json(arg);

--- a/source/model.cc
+++ b/source/model.cc
@@ -67,7 +67,7 @@ namespace sapc {
             return loc_json;
         };
 
-        doc["attributes"] = annotations_to_json(module.annotations);
+        doc["annotations"] = annotations_to_json(module.annotations);
 
         auto modules_json = json::array();
         for (auto const& module : module.imports)
@@ -86,7 +86,7 @@ namespace sapc {
             if (!type.base.empty())
                 type_json["base"] = type.base;
             if (!type.annotations.empty())
-                type_json["attributes"] = annotations_to_json(type.annotations);
+                type_json["annotations"] = annotations_to_json(type.annotations);
             type_json["location"] = loc_to_json(type.location);
 
             if (type.category == Type::Category::Enum) {
@@ -119,7 +119,7 @@ namespace sapc {
                     if (field.init.type != Value::Type::None)
                         field_json["default"] = json(field.init);
                     if (!field.annotations.empty())
-                        field_json["attributes"] = annotations_to_json(field.annotations);
+                        field_json["annotations"] = annotations_to_json(field.annotations);
                     field_json["location"] = loc_to_json(field.location);
                     fields.push_back(std::move(field_json));
                 }

--- a/source/model.cc
+++ b/source/model.cc
@@ -31,10 +31,10 @@ namespace sapc {
         doc["$schema"] = "https://raw.githubusercontent.com/potatoengine/sapc/master/schema/sap-1.schema.json";
         doc["module"] = module.name;
 
-        auto attrs_to_json = [&](std::vector<Attribute> const& attributes) -> nlohmann::json {
-            auto attrs_json = json::object();
-            for (auto const& attr : attributes) {
-                auto const it = module.typeMap.find(attr.name);
+        auto annotations_to_json = [&](std::vector<Annotation> const& annotations) -> nlohmann::json {
+            auto annotations_json = json::object();
+            for (auto const& annotation : annotations) {
+                auto const it = module.typeMap.find(annotation.name);
                 assert(it != module.typeMap.end());
                 assert(it->second < module.types.size());
 
@@ -42,19 +42,19 @@ namespace sapc {
                 assert(def.category == Type::Category::Attribute);
 
                 auto args_json = json::object();
-                for (size_t index = 0; index != attr.params.size(); ++index) {
-                    assert(def.fields.size() == attr.params.size());
+                for (size_t index = 0; index != annotation.params.size(); ++index) {
+                    assert(def.fields.size() == annotation.params.size());
 
                     auto const& param = def.fields[index];
-                    auto const& arg = attr.params[index];
+                    auto const& arg = annotation.params[index];
 
                     assert(arg.type != Value::Type::None);
                     args_json[param.name] = json(arg);
                 }
 
-                attrs_json[def.name].push_back(std::move(args_json));
+                annotations_json[def.name].push_back(std::move(args_json));
             }
-            return attrs_json;
+            return annotations_json;
         };
 
         auto loc_to_json = [&](Location const& loc) {
@@ -67,7 +67,7 @@ namespace sapc {
             return loc_json;
         };
 
-        doc["attributes"] = attrs_to_json(module.attributes);
+        doc["attributes"] = annotations_to_json(module.annotations);
 
         auto modules_json = json::array();
         for (auto const& module : module.imports)
@@ -85,8 +85,8 @@ namespace sapc {
             type_json["is_union"] = type.category == Type::Category::Union;
             if (!type.base.empty())
                 type_json["base"] = type.base;
-            if (!type.attributes.empty())
-                type_json["attributes"] = attrs_to_json(type.attributes);
+            if (!type.annotations.empty())
+                type_json["attributes"] = annotations_to_json(type.annotations);
             type_json["location"] = loc_to_json(type.location);
 
             if (type.category == Type::Category::Enum) {
@@ -118,8 +118,8 @@ namespace sapc {
                     field_json["is_array"] = field.type.isArray;
                     if (field.init.type != Value::Type::None)
                         field_json["default"] = json(field.init);
-                    if (!field.attributes.empty())
-                        field_json["attributes"] = attrs_to_json(field.attributes);
+                    if (!field.annotations.empty())
+                        field_json["attributes"] = annotations_to_json(field.annotations);
                     field_json["location"] = loc_to_json(field.location);
                     fields.push_back(std::move(field_json));
                 }

--- a/source/model.hh
+++ b/source/model.hh
@@ -41,7 +41,7 @@ namespace sapc {
 
     struct Annotation {
         std::string name;
-        std::vector<Value> params;
+        std::vector<Value> arguments;
         Location location;
     };
 

--- a/source/model.hh
+++ b/source/model.hh
@@ -39,7 +39,7 @@ namespace sapc {
         friend void to_json(nlohmann::json& j, Value const& value);
     };
 
-    struct Attribute {
+    struct Annotation {
         std::string name;
         std::vector<Value> params;
         Location location;
@@ -49,7 +49,7 @@ namespace sapc {
         std::string name;
         TypeInfo type;
         Value init;
-        std::vector<Attribute> attributes;
+        std::vector<Annotation> annotations;
         Location location;
     };
 
@@ -67,7 +67,7 @@ namespace sapc {
         std::string name;
         std::string base;
         std::string module;
-        std::vector<Attribute> attributes;
+        std::vector<Annotation> annotations;
         std::vector<TypeField> fields;
         Location location;
     };
@@ -75,7 +75,7 @@ namespace sapc {
     struct Module {
         std::string name;
         std::filesystem::path filename;
-        std::vector<Attribute> attributes;
+        std::vector<Annotation> annotations;
 
         std::set<std::string> imports;
 

--- a/test/gen_header.py
+++ b/test/gen_header.py
@@ -9,9 +9,9 @@ import re
 from os import path
 from datetime import datetime
 
-def attr(el, attrname, argname, default=None):
-    if el is not None and 'attributes' in el and attrname in el['attributes']:
-        return el['attributes'][attrname][0][argname]
+def annotation(el, name, argname, default=None):
+    if el is not None and 'annotations' in el and name in el['annotations']:
+        return el['annotations'][name][0][argname]
     else:
         return default
 
@@ -34,8 +34,8 @@ def cxxname(el):
     if 'is_builtin' in el and el['is_builtin'] and el['name'] in cxx_type_map:
         return cxx_type_map[el['name']]
     else:
-        return attr(el, attrname='cxxname', argname='name', default=identifier(el['name']))
-def ignored(el): return attr(el, attrname='ignore', argname='ignored', default=False)
+        return annotation(el, name='cxxname', argname='name', default=identifier(el['name']))
+def ignored(el): return annotation(el, name='ignore', argname='ignored', default=False)
 def namespace(el): return 'sapc_attr' if 'is_attribute' in el and el['is_attribute'] else 'sapc_type'
 
 def encode(el):
@@ -76,12 +76,12 @@ def main(argv):
 
     types = doc['types']
 
-    for attr, payload in doc['attributes'].items():
-        for attr_args in payload:
-            print(f'// attr: {attr}({",".join([k+":"+encode(v) for k,v in attr_args.items()])})', file=args.output)
+    for annotation, payload in doc['annotations'].items():
+        for annotation_args in payload:
+            print(f'// annotation: {annotation}({",".join([k+":"+encode(v) for k,v in annotation_args.items()])})', file=args.output)
 
     typemap = {type['name'] : type for type in types}
-
+        
     if 'imports' in doc:
         for module in doc['imports']:
             print(f'#include "{module}.h"', file=args.output)


### PR DESCRIPTION
Attributes are the declarations of types that can be applied as annotations.

Closes #38 