### PR TITLE
Simplify core names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ Version 0.15-beta (WIP)
  - Importing modules includes their custom tags in grammar parsing
  - Fix enums to apply custom tags
  - Custom tags for unions, aliases, and constants
+ - Rename $sapc, $sapc.customtag, and $sapc.typeid to $core, $customtag, $typeid, respectively
 
 Version 0.14-beta
 -----------------

--- a/source/compiler.cc
+++ b/source/compiler.cc
@@ -478,7 +478,7 @@ namespace sapc {
         schema::Module* mod = ctx.modules.emplace_back(std::make_unique<schema::Module>()).get();
         mod->root = ns;
         coreModule = mod;
-        mod->name = "$sapc";
+        mod->name = "$core";
         ns->owner = mod;
 
         for (auto const& builtin : builtins) {

--- a/source/compiler.cc
+++ b/source/compiler.cc
@@ -22,7 +22,7 @@ namespace fs = std::filesystem;
 namespace sapc {
     using namespace std::literals;
 
-    static constexpr auto typeIdName = "$sapc.typeid"sv;
+    static constexpr auto typeIdName = "typeid"sv;
     static constexpr auto customTagName = "$customtag"sv;
 
     namespace {

--- a/source/compiler.cc
+++ b/source/compiler.cc
@@ -23,7 +23,7 @@ namespace sapc {
     using namespace std::literals;
 
     static constexpr auto typeIdName = "$sapc.typeid"sv;
-    static constexpr auto customTagName = "$sapc.customtag"sv;
+    static constexpr auto customTagName = "$customtag"sv;
 
     namespace {
         // std::span isn't in C++17

--- a/test/gen_header.py
+++ b/test/gen_header.py
@@ -178,7 +178,7 @@ def main(argv):
         print('    static decltype(auto) get_annotation() {', file=args.output)
         for index,anno in enumerate(type['annotations']):
             anno_type = typemap[anno['type']]
-            if anno_type['name'] == '$sapc.customtag': continue
+            if anno_type['name'] == '$customtag': continue
 
             print(f'      if constexpr(N == {index}) {{', file=args.output)
             print(f'        static auto const anno = {qualified(anno_type)}{{', file=args.output)
@@ -266,7 +266,7 @@ def main(argv):
 
         name = cxxname(constant)
 
-        const_str = 'constexpr' if annotation(constant, '$sapc.customtag') == 'constexpr' else 'const'
+        const_str = 'constexpr' if annotation(constant, '$customtag') == 'constexpr' else 'const'
 
         if 'location' in constant:
             loc = constant['location']


### PR DESCRIPTION
 - Rename $sapc, $sapc.customtag, and $sapc.typeid to $core, $customtag, $typeid, respectively